### PR TITLE
Attempt to parse misconfigured license declaration

### DIFF
--- a/lib/parseLicense.js
+++ b/lib/parseLicense.js
@@ -10,10 +10,18 @@ function parse (file) {
       return handleUndefinedAndNull(file.license.type)
     }
   }
-  
+
   if (file.licenses !== undefined) {
-    return handleUndefinedAndNull(file.licenses[0].type)
+    if (Array.isArray(file.licenses)) {
+      return handleUndefinedAndNull(file.licenses[0].type)
+    }
+
+    if (typeof file.licenses === 'object') {
+      return handleUndefinedAndNull(file.licenses.type)
+    }
   }
+
+  return handleUndefinedAndNull(undefined)
 }
 
 function handleUndefinedAndNull (licenseString) {

--- a/tests/dummy/package.misconfiguredObjectType.json
+++ b/tests/dummy/package.misconfiguredObjectType.json
@@ -1,0 +1,3 @@
+{
+  "licenses": {"type": "LMAO"}
+}

--- a/tests/dummy/package.stringType.json
+++ b/tests/dummy/package.stringType.json
@@ -1,0 +1,3 @@
+{
+  "license": "BRB"
+}

--- a/tests/parseLicense.test.js
+++ b/tests/parseLicense.test.js
@@ -13,12 +13,38 @@ describe('test `license` export', () => {
     )
   })
 
+  test('test the output of an string that is identified by `license`', () => {
+    const pkg = loadPackagejson.sync(`${__dirname}/dummy/package.stringType.json`)
+    const actual = parseLicense(pkg)
+
+    expect(actual).toEqual(
+      'BRB'
+    )
+  })
+
   test('test the output of an object that is identified by `license` which has a `type` property', () => {
     const pkg = loadPackagejson.sync(`${__dirname}/dummy/package.objectType.json`)
     const actual = parseLicense(pkg)
 
     expect(actual).toEqual(
       'OMG'
+    )
+  })
+
+  test('test the output of an array that is identified by `licenses` but misconfigured as a single object', () => {
+    const pkg = loadPackagejson.sync(`${__dirname}/dummy/package.misconfiguredObjectType.json`)
+    const actual = parseLicense(pkg)
+
+    expect(actual).toEqual(
+      'LMAO'
+    )
+  })
+
+  test('test the output of a missing license object is informative placeholder text', () => {
+    const actual = parseLicense({})
+
+    expect(actual).toEqual(
+      'invalid license'
     )
   })
 


### PR DESCRIPTION
Running `delice` on a project kept failing to parse the [emojione package.json licenses declaration](https://github.com/joypixels/emojione/blob/master/package.json), since it's misconfigured as an object, and not an array.

```
"licenses": {
  "type": "(MIT)",
  "url": "https://github.com/emojione/emojione/blob/master/LICENSE.md"
},
```

This PR attempts to address missing and misconfigured `licenses` declarations by handling `objects`. I considered ignoring it and simply return "invalid license", but since this was the only case, it felt better to address it "correctly".