### PR TITLE
feat: paths to license export

### DIFF
--- a/examples/licenses.js
+++ b/examples/licenses.js
@@ -5,4 +5,4 @@ const { licenses } = require('../index')
 
 // We're looking at /tests since it has a dummy set of package.jsons for this express purpose.
 // Note that we're using a relative path as well. Both relative and absolute paths are accepted.
-console.log(JSON.stringify(licenses('../tests'), null, 2))
+console.log(JSON.stringify(licenses('./tests'), null, 2))

--- a/exports/licenses.js
+++ b/exports/licenses.js
@@ -6,7 +6,8 @@ const buildObjectLicenseReport = function (directory) {
 
   for (var checkedModule in data) { // loop over data that we pulled in
     const licenseName = data[checkedModule].license // short hand for license names on each loop
-    const versionNumber = data[checkedModule].version // short hand for license names on each loop
+    const versionNumber = data[checkedModule].version // short hand for module version on each loop
+    const modulePath = data[checkedModule].path // short hand for module path on each loop
     const conformance = data[checkedModule].conformance
 
     if (report[licenseName] === undefined) {
@@ -17,12 +18,17 @@ const buildObjectLicenseReport = function (directory) {
       report[licenseName].packages = {} // if the packages property is not an object on the license name we're currently iteracting over, define it
     }
 
+    if (report[licenseName].paths === undefined) {
+      report[licenseName].paths = {} // if the path property is not an object on the license name we're currently iterating over, define it
+    }
+
     if (report[licenseName].conformance === undefined) {
       report[licenseName].conformance = {} // if the conformance property is not an object on the license name we're currently iterating over, define it
     }
 
     report[licenseName].occurrences = (report[licenseName].occurrences || 0) + 1 // add one to the occurrence property each loop that the license name exists
     report[licenseName].packages[checkedModule] = versionNumber // for each module that's of a license type, add it as a property to the packages property and assgin its value as the installed version
+    report[licenseName].paths[checkedModule] = modulePath
     report[licenseName].conformance = conformance
   }
 

--- a/tests/license.test.js
+++ b/tests/license.test.js
@@ -29,6 +29,27 @@ describe('test `license` export', () => {
             "strip-bom": "4.0.0",
             "supports-color": "5.5.0"
           },
+          "paths": {
+            "@babel/code-frame": "tests/node_modules/@babel/code-frame/package.json",
+            "chalk": "tests/node_modules/chalk/package.json",
+            "color-convert": "tests/node_modules/color-convert/package.json",
+            "color-name": "tests/node_modules/color-name/package.json",
+            "conformance": "tests/node_modules/conformance/package.json",
+            "deep-is": "tests/node_modules/deep-is/package.json",
+            "error-ex": "tests/node_modules/error-ex/package.json",
+            "escape-string-regexp": "tests/node_modules/escape-string-regexp/package.json",
+            "has-flag": "tests/node_modules/has-flag/package.json",
+            "is-arrayish": "tests/node_modules/is-arrayish/package.json",
+            "js-tokens": "tests/node_modules/js-tokens/package.json",
+            "json-parse-better-errors": "tests/node_modules/json-parse-better-errors/package.json",
+            "lines-and-columns": "tests/node_modules/lines-and-columns/package.json",
+            "load-json-file": "tests/node_modules/load-json-file/package.json",
+            "parse-json": "tests/node_modules/parse-json/package.json",
+            "querystring": "tests/node_modules/querystring/package.json",
+            "spdx-expression-parse": "tests/node_modules/spdx-expression-parse/package.json",
+            "strip-bom": "tests/node_modules/strip-bom/package.json",
+            "supports-color": "tests/node_modules/supports-color/package.json"
+          },
           "conformance": {
             "uniqueLicenseIds": [
               "MIT"
@@ -49,6 +70,9 @@ describe('test `license` export', () => {
           "packages": {
             "esutils": "2.0.2"
           },
+          "paths": {
+            "esutils": "tests/node_modules/esutils/package.json"
+          },
           "conformance": {
             "license": "BSD",
             "error": "Passed license expression was not a valid license expression. Error from spdx-expression-parse: Error: Unexpected `B` at offset 0"
@@ -59,6 +83,9 @@ describe('test `license` export', () => {
           "packages": {
             "fakefail": "0.2.0"
           },
+          "paths": {
+            "fakefail": "tests/node_modules/fakefail/package.json"
+          },
           "conformance": {
             "license": "invalid license",
             "error": "Passed license expression was not a valid license expression. Error from spdx-expression-parse: Error: Unexpected `i` at offset 0"
@@ -68,6 +95,9 @@ describe('test `license` export', () => {
         "ISC": {
           "packages": {
             "graceful-fs": "4.2.0"
+          },
+          "paths": {
+            "graceful-fs": "tests/node_modules/graceful-fs/package.json"
           },
           "conformance": {
             "uniqueLicenseIds": [
@@ -89,6 +119,9 @@ describe('test `license` export', () => {
           "packages": {
             "spdx-exceptions": "2.2.0"
           },
+          "paths": {
+            "spdx-exceptions": "tests/node_modules/spdx-exceptions/package.json"
+          },
           "conformance": {
             "uniqueLicenseIds": [
               "CC-BY-3.0"
@@ -108,6 +141,9 @@ describe('test `license` export', () => {
         "CC0-1.0": {
           "packages": {
             "spdx-license-ids": "3.0.5"
+          },
+          "paths": {
+            "spdx-license-ids": "tests/node_modules/spdx-license-ids/package.json"
           },
           "conformance": {
             "uniqueLicenseIds": [
@@ -129,6 +165,9 @@ describe('test `license` export', () => {
           "packages": {
             "type-fest": "0.6.0"
           },
+          "paths": {
+            "type-fest": "tests/node_modules/type-fest/package.json"
+          },
           "conformance": {
             "uniqueLicenseIds": [
               "MIT",
@@ -147,7 +186,7 @@ describe('test `license` export', () => {
           },
           "occurrences": 1
         }
-      }    
+      }
     )
   })
 })

--- a/tests/outputs/licenses.json
+++ b/tests/outputs/licenses.json
@@ -21,6 +21,27 @@
       "strip-bom": "4.0.0",
       "supports-color": "5.5.0"
     },
+    "paths": {
+      "@babel/code-frame": "tests/node_modules/@babel/code-frame/package.json",
+      "chalk": "tests/node_modules/chalk/package.json",
+      "color-convert": "tests/node_modules/color-convert/package.json",
+      "color-name": "tests/node_modules/color-name/package.json",
+      "conformance": "tests/node_modules/conformance/package.json",
+      "deep-is": "tests/node_modules/deep-is/package.json",
+      "error-ex": "tests/node_modules/error-ex/package.json",
+      "escape-string-regexp": "tests/node_modules/escape-string-regexp/package.json",
+      "has-flag": "tests/node_modules/has-flag/package.json",
+      "is-arrayish": "tests/node_modules/is-arrayish/package.json",
+      "js-tokens": "tests/node_modules/js-tokens/package.json",
+      "json-parse-better-errors": "tests/node_modules/json-parse-better-errors/package.json",
+      "lines-and-columns": "tests/node_modules/lines-and-columns/package.json",
+      "load-json-file": "tests/node_modules/load-json-file/package.json",
+      "parse-json": "tests/node_modules/parse-json/package.json",
+      "querystring": "tests/node_modules/querystring/package.json",
+      "spdx-expression-parse": "tests/node_modules/spdx-expression-parse/package.json",
+      "strip-bom": "tests/node_modules/strip-bom/package.json",
+      "supports-color": "tests/node_modules/supports-color/package.json"
+    },
     "conformance": {
       "uniqueLicenseIds": [
         "MIT"
@@ -41,6 +62,9 @@
     "packages": {
       "esutils": "2.0.2"
     },
+    "paths": {
+      "esutils": "tests/node_modules/esutils/package.json"
+    },
     "conformance": {
       "license": "BSD",
       "error": "Passed license expression was not a valid license expression. Error from spdx-expression-parse: Error: Unexpected `B` at offset 0"
@@ -51,6 +75,9 @@
     "packages": {
       "fakefail": "0.2.0"
     },
+    "paths": {
+      "fakefail": "tests/node_modules/fakefail/package.json"
+    },
     "conformance": {
       "license": "invalid license",
       "error": "Passed license expression was not a valid license expression. Error from spdx-expression-parse: Error: Unexpected `i` at offset 0"
@@ -60,6 +87,9 @@
   "ISC": {
     "packages": {
       "graceful-fs": "4.2.0"
+    },
+    "paths": {
+      "graceful-fs": "tests/node_modules/graceful-fs/package.json"
     },
     "conformance": {
       "uniqueLicenseIds": [
@@ -81,6 +111,9 @@
     "packages": {
       "spdx-exceptions": "2.2.0"
     },
+    "paths": {
+      "spdx-exceptions": "tests/node_modules/spdx-exceptions/package.json"
+    },
     "conformance": {
       "uniqueLicenseIds": [
         "CC-BY-3.0"
@@ -101,6 +134,9 @@
     "packages": {
       "spdx-license-ids": "3.0.5"
     },
+    "paths": {
+      "spdx-license-ids": "tests/node_modules/spdx-license-ids/package.json"
+    },
     "conformance": {
       "uniqueLicenseIds": [
         "CC0-1.0"
@@ -120,6 +156,9 @@
   "(MIT OR CC0-1.0)": {
     "packages": {
       "type-fest": "0.6.0"
+    },
+    "paths": {
+      "type-fest": "tests/node_modules/type-fest/package.json"
     },
     "conformance": {
       "uniqueLicenseIds": [


### PR DESCRIPTION
inherits paths from module and then adds them to the `paths` object with the key as the name oof the module and the value as the path to the parsed `package.json`