### PR TITLE
refactor: add arborist

### DIFF
--- a/examples/arborist.js
+++ b/examples/arborist.js
@@ -1,0 +1,13 @@
+// Run this in the root project directory:
+// $ node examples/list-my-licenses.js
+
+const arborist = require('../exports/arbor')
+
+// We're looking at /tests since it has a dummy set of package.jsons for this express purpose.
+// Note that we're using a relative path as well. Both relative and absolute paths are accepted.
+async function log () {
+  const modulesFromArborist = await arborist(`${process.cwd()}/tests`)
+  console.log(JSON.stringify(modulesFromArborist, null, 2))
+}
+
+log()

--- a/exports/arbor.js
+++ b/exports/arbor.js
@@ -1,0 +1,45 @@
+const Arborist = require('@npmcli/arborist')
+const conformance = require('conformance')
+
+const properties = {}
+
+async function executeArborist (path) { // our export
+  const arboristOptions = {}
+
+  if (path) { // only use the options that arborist actually takes
+    arboristOptions.path = path
+  }
+
+  const arborist = new Arborist(arboristOptions)
+
+  const tree = arborist.loadActual().then(node => {
+    node.children.forEach(packageMapHandler) // iterate over the chidlren Map() with the packageMapHandler method
+  }).then(() => {
+    return properties // once iteration is complete, return the data
+  }).catch((error) => {
+    throw error
+  })
+
+  return tree
+}
+
+async function packageMapHandler (value, key, map) {
+  const symbols = Object.getOwnPropertySymbols(value) // simple way to access the symbols
+  const module = map.get(key) // 'key' is the name of the currently iterated module - this gets that value
+  const _package = module[symbols[0]] // gets additional metadata that we need stored in the Symbol(_package) in map.get(key)
+
+  const iteration = {
+    name: module.name,
+    license: _package.license,
+    path: module.realpath, // I just assumed realpath was the best option - path may be better
+    version: _package.version,
+    author: _package.author,
+    conformance: conformance(_package.license) // build conformance profile from the license
+  }
+
+  if (properties[iteration.name] === undefined) {
+    properties[iteration.name] = iteration
+  }
+}
+
+module.exports = executeArborist

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Tierney Cyren <hello@bnb.im>",
   "license": "MIT",
   "dependencies": {
+    "@npmcli/arborist": "0.0.0-pre.6",
     "conformance": "^1.0.0",
     "load-json-file": "^6.1.0"
   },


### PR DESCRIPTION
initial step toward a rewrite with [@npmcli/arborist](http://npm.im/@npmcli/arborist). The `exports/arbor.js` file would theoretically replace `lib/module.js`.

Current notes: does not resolve deterministically like the current implementation does. 